### PR TITLE
Ignoring case during string check

### DIFF
--- a/autoload/clipper/private.vim
+++ b/autoload/clipper/private.vim
@@ -43,7 +43,7 @@ function! clipper#private#executable() abort
     " - CentOS etc:
     "     Does not support or need -N.
     let l:help = system('nc -h')
-    if match(l:help, '\v\s-N\s.+shutdown>') != -1
+    if match(l:help, '\c\v\s-N\s.+shutdown>') != -1
       let s:executable = 'nc -N'
     else
       let s:executable = 'nc'


### PR DESCRIPTION
What was previous written as "shutdown(2)" in the older version, is now written as "Shutdown", what breaks the string check and causes the netcat binary to be invoked without the "-N" option. This fix expands the check behaviour to ignore the case (\c), which causes the Linux netcat binary to be properly detected. 

Closes #4 