### PR TITLE
Add mapping to enable only auto-copying the system registers + and *

### DIFF
--- a/autoload/clipper/private.vim
+++ b/autoload/clipper/private.vim
@@ -7,19 +7,20 @@ function! clipper#private#set_invocation(method) abort
   endif
 endfunction
 
-function! clipper#private#clip() abort
+function! clipper#private#clip(...) abort
+  let l:regname = get(a:, 1, '0') " default to @0 register
   if exists('s:invocation') && s:invocation != ''
-    call system(s:invocation, @0)
+    call system(s:invocation, getreg(l:regname))
   elseif clipper#private#executable() != ''
     let l:executable = clipper#private#executable()
     let l:address = get(g:, 'ClipperAddress', 'localhost')
     let l:port = +(get(g:, 'ClipperPort', 8377)) " Co-erce to number.
     if l:port
       " nc
-      call system(l:executable . ' ' . l:address . ' ' . l:port, @0)
+      call system(l:executable . ' ' . l:address . ' ' . l:port, getreg(l:regname))
     else
       " nc -U
-      call system(l:executable . ' -U ' . l:address, @0)
+      call system(l:executable . ' -U ' . l:address, getreg(l:regname))
     endif
   else
     echoerr 'Clipper: nc executable does not exist'

--- a/doc/clipper.txt
+++ b/doc/clipper.txt
@@ -106,6 +106,14 @@ OPTIONS                                                       *clipper-options*
 
     let g:ClipperAuto=0
 <
+                                                      *g:ClipperAutoSystemOnly*
+  |g:ClipperAutoSystemOnly|                                boolean (default: 0)
+
+  When set to 1, |g:ClipperAuto| will only route text yanked to a system
+  register, i.e. '*' and '+', to Clipper. >
+
+    let g:ClipperAutoSystemOnly=1
+<
                                                                  *g:ClipperMap*
   |g:ClipperMap|                                           boolean (default: 1)
 

--- a/plugin/clipper.vim
+++ b/plugin/clipper.vim
@@ -22,11 +22,20 @@ if s:map
 endif
 nnoremap <Plug>(ClipperClip) :Clip<CR>
 
+function! ClipperMaybeClip(event)
+  let l:system=get(g:, 'ClipperAutoSystemOnly', 0)
+  if l:system == 1 && a:event.operator ==# 'y' && (a:event.regname == '+' || a:event.regname == '*')
+    call clipper#private#clip(a:event.regname)
+  elseif l:system == 0 && a:event.operator ==# 'y'
+    call clipper#private#clip(0)
+  endif
+endfunction
+
 let s:auto=get(g:, 'ClipperAuto', 1)
 if s:auto && exists('##TextYankPost')
   augroup Clipper
     autocmd!
-    autocmd TextYankPost * if v:event.operator ==# 'y' | call clipper#private#clip() | endif
+    autocmd TextYankPost * call ClipperMaybeClip(v:event)
   augroup END
 endif
 


### PR DESCRIPTION
Setting `g:ClipperAutoSystemOnly` to 1 causes the `TextYankPost` call to only send the `+` and `*` registers to Clipper.

I made this because I didn't like sending everything I yank/delete in my remote Vim session back to my local machine, which fills up my clipboard history (CopyClip2) with a lot of junk. I'm already accustomed to hitting `"+y` in Vim anyway, since that's how I copy to the "system" clipboard in macOS. This makes vim-clipper operate more like I expect my local Vim to work.

But I realize this is probably not for everyone, which is why it's disabled by default.

Thanks for your consideration! (If you choose not to merge this, no worries, as I can just keep my fork going for my own personal use. Thanks!)

[Forgot to add: Clipper and vim-clipper are really awesome; thanks for sharing them with the world!]